### PR TITLE
Fixes issue with player replacement key error

### DIFF
--- a/votecount.py
+++ b/votecount.py
@@ -498,8 +498,8 @@ def scrapeThread(thread_id, om=False):
                                     newplayer = n.group(2)
                                     nickname = n.group(3)
 
-                                if ("username" in players[replaced]):
-                                    replaced = players[replaced]["username"]
+                                if ("username" in players[replaced.lower()]):
+                                    replaced = players[replaced.lower()]["username"]
 
                                 players[newplayer.lower()] = {"pronouns":pronoun, "name":newplayer, "nickname":nickname, "timezone":timezone, "status": "alive", "flip_post":None, "replaces":replaced.lower(), "replaced_by":None}
                                 players[replaced.lower()]["status"] = "replaced"


### PR DESCRIPTION
A key error had been introduced by not converting the replaced player's name to an all-lowercase version so it could be used for searching within the players dictionary.